### PR TITLE
fix(linter): disable linting from rust 2015 edition

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -58,5 +58,6 @@ jobs:
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_BASH: false
           VALIDATE_JSCPD: false
+          VALIDATE_RUST_2015: false
           
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Prevents issues such as linting failures due to usage of `async`, which have been accounted for in the 2018 edition