### PR TITLE
update linter.yml to not validate using isort

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -56,7 +56,7 @@ jobs:
           VALIDATE_DOCKERFILE: false
           VALIDATE_DOCKERFILE_HADOLINT: false
           VALIDATE_PYTHON_FLAKE8: false
-          VALIDATE_PYTHON_ISORT: false
+          PYTHON_ISORT_CONFIG_FILE: .isort.cfg
           VALIDATE_BASH: false
           VALIDATE_JSCPD: false
           VALIDATE_RUST_2015: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -56,6 +56,7 @@ jobs:
           VALIDATE_DOCKERFILE: false
           VALIDATE_DOCKERFILE_HADOLINT: false
           VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false
           VALIDATE_BASH: false
           VALIDATE_JSCPD: false
           VALIDATE_RUST_2015: false


### PR DESCRIPTION
isort and black conflict with each other. Hence, disabling isort.
@SaurusXI @BRO3886 @SphericalKat 